### PR TITLE
restored TaskUtil.executeParallelFailFast method since core can be us…

### DIFF
--- a/management/server/subutai-common/src/main/java/io/subutai/common/util/TaskUtil.java
+++ b/management/server/subutai-common/src/main/java/io/subutai/common/util/TaskUtil.java
@@ -51,6 +51,22 @@ public class TaskUtil<T>
     }
 
 
+    /**
+     * Executes tasks in parallel. Fails fast if any execution failed
+     *
+     * Returns results of tasks completed so far
+     */
+    public TaskResults<T> executeParallelFailFast()
+    {
+        Preconditions.checkArgument( !CollectionUtil.isCollectionEmpty( tasks ), "No task found for execution" );
+
+        Set<TaskResult<T>> results = executeParallel( tasks, true );
+
+        tasks.clear();
+
+        return new TaskResults<>( results );
+    }
+
 
     protected Set<TaskResult<T>> executeParallel( Set<Task<T>> tasks, boolean failFast )
     {
@@ -242,7 +258,7 @@ public class TaskUtil<T>
         }
         catch ( InterruptedException e )
         {
-            LOG.error( e.getMessage() );
+            LOG.warn( e.getMessage() );
         }
     }
 }


### PR DESCRIPTION
This core api method can be used by plugins and third party addons and this method can be useful