### PR TITLE
SS should update p2p keys only for local environments

### DIFF
--- a/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/EnvironmentManagerImpl.java
+++ b/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/EnvironmentManagerImpl.java
@@ -1822,7 +1822,8 @@ public class EnvironmentManagerImpl implements EnvironmentManager, PeerActionLis
     {
         try
         {
-            for ( Environment environment : getEnvironments() )
+            //process only SS side environments
+            for ( Environment environment : environmentService.getAll() )
             {
                 if ( !( environment.getStatus() == EnvironmentStatus.UNDER_MODIFICATION
                         || environment.getStatus() == EnvironmentStatus.CANCELLED ) )


### PR DESCRIPTION
SS should update p2p keys for env-s created locally. It should not try to do it to Hub env-s because it is not initiator. Hub should do this. Otherwise all participating peers can attempt to do it simulatenously