### PR TITLE
Sometimes Hub delegate user not created. 

### DIFF
--- a/management/server/core/hub-manager/hub-manager-impl/src/main/java/io/subutai/core/hubmanager/impl/processor/EnvironmentUserHelper.java
+++ b/management/server/core/hub-manager/hub-manager-impl/src/main/java/io/subutai/core/hubmanager/impl/processor/EnvironmentUserHelper.java
@@ -141,8 +141,9 @@ public class EnvironmentUserHelper
     {
         for ( User user : identityManager.getAllUsers() )
         {
-            // Email contains the user id in Hub
-            if ( user.getEmail().startsWith( userId ) )
+            String email = user.getEmail();
+            String username = email.substring( 0, email.indexOf( "@" ) );
+            if ( username.equals( userId ) )
             {
                 return user;
             }

--- a/management/server/core/hub-manager/hub-manager-impl/src/main/java/io/subutai/core/hubmanager/impl/processor/EnvironmentUserHelper.java
+++ b/management/server/core/hub-manager/hub-manager-impl/src/main/java/io/subutai/core/hubmanager/impl/processor/EnvironmentUserHelper.java
@@ -141,9 +141,8 @@ public class EnvironmentUserHelper
     {
         for ( User user : identityManager.getAllUsers() )
         {
-            String email = user.getEmail();
-            String username = email.substring( 0, email.indexOf( "@" ) );
-            if ( username.equals( userId ) )
+            String email = userId + HubManager.HUB_EMAIL_SUFFIX;
+            if ( user.getEmail().equals( email ) )
             {
                 return user;
             }


### PR DESCRIPTION
Improve delegate user creation on SS. Currently, when creating delegate user, checks if exists user ID on the beginning of the email. 