### PR TITLE
Hotfix fix npe

### DIFF
--- a/management/server/core/hub-manager/hub-manager-impl/src/main/java/io/subutai/core/hubmanager/impl/environment/HubEnvironmentProcessor.java
+++ b/management/server/core/hub-manager/hub-manager-impl/src/main/java/io/subutai/core/hubmanager/impl/environment/HubEnvironmentProcessor.java
@@ -80,7 +80,7 @@ public class HubEnvironmentProcessor implements StateLinkProcessor
         }
         catch ( Exception e )
         {
-                throw new HubManagerException( e );
+            throw new HubManagerException( e );
         }
         finally
         {

--- a/management/server/core/hub-manager/hub-manager-impl/src/main/java/io/subutai/core/hubmanager/impl/environment/state/StateHandler.java
+++ b/management/server/core/hub-manager/hub-manager-impl/src/main/java/io/subutai/core/hubmanager/impl/environment/state/StateHandler.java
@@ -1,19 +1,17 @@
 package io.subutai.core.hubmanager.impl.environment.state;
 
 
-import java.io.IOException;
 import java.security.PrivilegedAction;
 
 import javax.security.auth.Subject;
 
-import org.bouncycastle.openpgp.PGPException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.commons.lang3.StringUtils;
 
-import io.subutai.core.hubmanager.api.exception.HubManagerException;
 import io.subutai.core.hubmanager.api.RestResult;
+import io.subutai.core.hubmanager.api.exception.HubManagerException;
 import io.subutai.core.identity.api.IdentityManager;
 import io.subutai.core.identity.api.model.Session;
 import io.subutai.core.identity.api.model.UserToken;
@@ -76,7 +74,7 @@ public abstract class StateHandler
             UserToken userToken = ctx.envUserHelper.getUserTokenFromHub( peerDto.getEnvironmentInfo().getSsOwnerId() );
             return userToken.getFullToken();
         }
-        catch ( HubManagerException | PGPException | IOException e )
+        catch ( Exception e )
         {
             log.error( e.getMessage() );
         }


### PR DESCRIPTION
fix NPE
`2017-08-03 05:12:34,192 | ERROR | pool-48-thread-1 | HeartbeatProcessor               | 206 - io.subutai.core.hubmanager.impl - 4.0.16.SNAPSHOT | Error to process state links: 
io.subutai.core.hubmanager.api.exception.HubManagerException: java.lang.NullPointerException
	at io.subutai.core.hubmanager.impl.environment.HubEnvironmentProcessor.processStateLink(HubEnvironmentProcessor.java:83)[206:io.subutai.core.hubmanager.impl:4.0.16.SNAPSHOT]
	at io.subutai.core.hubmanager.impl.environment.HubEnvironmentProcessor.processStateLinks(HubEnvironmentProcessor.java:52)[206:io.subutai.core.hubmanager.impl:4.0.16.SNAPSHOT]
	at io.subutai.core.hubmanager.impl.processor.HeartbeatProcessor$2.run(HeartbeatProcessor.java:236)[206:io.subutai.core.hubmanager.impl:4.0.16.SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)[:1.8.0_111]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)[:1.8.0_111]
	at java.lang.Thread.run(Thread.java:745)[:1.8.0_111]
Caused by: java.lang.NullPointerException
	at io.subutai.core.hubmanager.impl.environment.state.StateHandler.getToken(StateHandler.java:76)[206:io.subutai.core.hubmanager.impl:4.0.16.SNAPSHOT]
	at io.subutai.core.hubmanager.impl.environment.state.StateHandler.handle(StateHandler.java:50)[206:io.subutai.core.hubmanager.impl:4.0.16.SNAPSHOT]
	at io.subutai.core.hubmanager.impl.environment.HubEnvironmentProcessor.processStateLink(HubEnvironmentProcessor.java:79)[206:io.subutai.core.hubmanager.impl:4.0.16.SNAPSHOT]
	... 5 more`