### PR TITLE
Base 1981

### DIFF
--- a/management/server/core/command-executor/command-executor-impl/src/main/java/io/subutai/core/executor/impl/CommandProcessor.java
+++ b/management/server/core/command-executor/command-executor-impl/src/main/java/io/subutai/core/executor/impl/CommandProcessor.java
@@ -29,6 +29,7 @@ import io.subutai.common.command.CommandResult;
 import io.subutai.common.command.Request;
 import io.subutai.common.command.Response;
 import io.subutai.common.host.ContainerHostInfo;
+import io.subutai.common.host.ContainerHostState;
 import io.subutai.common.host.HeartBeat;
 import io.subutai.common.host.HeartbeatListener;
 import io.subutai.common.host.ResourceHostInfo;
@@ -150,6 +151,15 @@ public class CommandProcessor implements RestProcessor
         try
         {
             resourceHostInfo = getResourceHostInfo( request.getId() );
+
+            if ( !resourceHostInfo.getId().equals( request.getId() ) )
+            {
+                //in case the target host is a container, ensure its state is RUNNING, otherwise throw exception
+                if ( hostRegistry.getContainerHostInfoById( request.getId() ).getState() != ContainerHostState.RUNNING )
+                {
+                    throw new CommandException( "Container is not running" );
+                }
+            }
         }
         catch ( HostDisconnectedException e )
         {

--- a/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/workflow/creation/steps/AddSshKeyStep.java
+++ b/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/workflow/creation/steps/AddSshKeyStep.java
@@ -74,7 +74,6 @@ public class AddSshKeyStep
                 throw new EnvironmentManagerException( "Failed to add SSH key on all peers" );
             }
 
-            environment.addSshKey( sshKey );
         }
     }
 }

--- a/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/workflow/modification/SshKeyAdditionWorkflow.java
+++ b/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/workflow/modification/SshKeyAdditionWorkflow.java
@@ -58,6 +58,8 @@ public class SshKeyAdditionWorkflow extends CancellableWorkflow<SshKeyAdditionWo
 
         try
         {
+            environment.addSshKey( sshKey );
+
             new AddSshKeyStep( sshKey, environment, operationTracker ).execute();
 
             saveEnvironment();

--- a/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/workflow/modification/SshKeyAdditionWorkflow.java
+++ b/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/workflow/modification/SshKeyAdditionWorkflow.java
@@ -60,6 +60,8 @@ public class SshKeyAdditionWorkflow extends CancellableWorkflow<SshKeyAdditionWo
         {
             environment.addSshKey( sshKey );
 
+            saveEnvironment();
+
             new AddSshKeyStep( sshKey, environment, operationTracker ).execute();
 
             saveEnvironment();

--- a/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/workflow/modification/SshKeyAdditionWorkflow.java
+++ b/management/server/core/environment-manager/environment-manager-impl/src/main/java/io/subutai/core/environment/impl/workflow/modification/SshKeyAdditionWorkflow.java
@@ -60,8 +60,6 @@ public class SshKeyAdditionWorkflow extends CancellableWorkflow<SshKeyAdditionWo
         {
             environment.addSshKey( sshKey );
 
-            saveEnvironment();
-
             new AddSshKeyStep( sshKey, environment, operationTracker ).execute();
 
             saveEnvironment();

--- a/management/server/core/environment-manager/environment-manager-impl/src/test/java/io/subutai/core/environment/impl/workflow/creation/steps/AddSshKeyStepTest.java
+++ b/management/server/core/environment-manager/environment-manager-impl/src/test/java/io/subutai/core/environment/impl/workflow/creation/steps/AddSshKeyStepTest.java
@@ -13,6 +13,7 @@ import io.subutai.core.environment.api.exception.EnvironmentManagerException;
 import io.subutai.core.environment.impl.TestHelper;
 import io.subutai.core.environment.impl.entity.LocalEnvironment;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
@@ -48,7 +49,7 @@ public class AddSshKeyStepTest
     {
         step.execute();
 
-        verify( environment ).addSshKey( TestHelper.SSH_KEY );
+        verify( PEER_UTIL ).addPeerTask( any( PeerUtil.PeerTask.class ) );
 
         doReturn( true ).when( peerTaskResult ).hasSucceeded();
 

--- a/management/server/core/environment-manager/environment-manager-impl/src/test/java/io/subutai/core/environment/impl/workflow/modification/SshKeyAdditionWorkflowTest.java
+++ b/management/server/core/environment-manager/environment-manager-impl/src/test/java/io/subutai/core/environment/impl/workflow/modification/SshKeyAdditionWorkflowTest.java
@@ -13,6 +13,7 @@ import io.subutai.core.environment.impl.TestHelper;
 import io.subutai.core.environment.impl.entity.LocalEnvironment;
 
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,7 +52,8 @@ public class SshKeyAdditionWorkflowTest
     public void setUp() throws Exception
     {
 
-        workflow = new SshKeyAdditionWorkflowSUT( environment, TestHelper.SSH_KEY, trackerOperation, environmentManager );
+        workflow =
+                new SshKeyAdditionWorkflowSUT( environment, TestHelper.SSH_KEY, trackerOperation, environmentManager );
 
         doReturn( environment ).when( environmentManager ).update( environment );
     }
@@ -71,7 +73,7 @@ public class SshKeyAdditionWorkflowTest
     {
         workflow.ADD_KEY();
 
-        verify( environmentManager ).update( environment );
+        verify( environmentManager, atLeastOnce() ).update( environment );
     }
 
 
@@ -92,6 +94,7 @@ public class SshKeyAdditionWorkflowTest
 
         verify( trackerOperation ).addLogFailed( anyString() );
     }
+
 
     @Test
     public void testOnCancellation() throws Exception

--- a/management/server/webui/src/main/webapp/subutai-app/environment/controller.js
+++ b/management/server/webui/src/main/webapp/subutai-app/environment/controller.js
@@ -567,8 +567,8 @@ function EnvironmentViewCtrl($scope, $rootScope, environmentService, trackerSrv,
 
 			vm.sshKeysList.splice(index, 1);
 			LOADING_SCREEN('none');
-		}).error( function(error) {
-			SweetAlert.swal("Error", "Error: " + error, "error");
+		}).error( function(data) {
+			SweetAlert.swal("Error", "Error: " + data.ERROR, "error");
 			ngDialog.closeAll();
 			LOADING_SCREEN('none');
 		});


### PR DESCRIPTION
#1981
Now SSH key is saved with environment even if there were failures during ssh key addition to all hosts.
This allows to remove this key later from the environment.
In case there are not running containers during removal of ssh key, the key is also left untouched in the environment to enable removal retrial by user later on.